### PR TITLE
Move special model registration to correct event

### DIFF
--- a/src/main/java/com/refinedmods/refinedpipes/RefinedPipes.java
+++ b/src/main/java/com/refinedmods/refinedpipes/RefinedPipes.java
@@ -26,8 +26,7 @@ public class RefinedPipes {
 
     public RefinedPipes() {
         DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> {
-            FMLJavaModLoadingContext.get().getModEventBus().addListener(ClientSetup::onClientSetup);
-            FMLJavaModLoadingContext.get().getModEventBus().addListener(ClientSetup::onModelBake);
+            FMLJavaModLoadingContext.get().getModEventBus().register(ClientSetup.class);
         });
 
         ModLoadingContext.get().registerConfig(ModConfig.Type.SERVER, SERVER_CONFIG.getSpec());

--- a/src/main/java/com/refinedmods/refinedpipes/setup/ClientSetup.java
+++ b/src/main/java/com/refinedmods/refinedpipes/setup/ClientSetup.java
@@ -21,6 +21,7 @@ import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.client.event.ModelBakeEvent;
+import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.client.model.ForgeModelBakery;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
@@ -38,7 +39,7 @@ public final class ClientSetup {
     }
 
     @SubscribeEvent
-    public static void onClientSetup(FMLClientSetupEvent e) {
+    public static void registerSpecialModels(ModelRegistryEvent ev) {
         for (AttachmentFactory factory : AttachmentRegistry.INSTANCE.all()) {
             LOGGER.debug("Registering attachment model {}", factory.getModelLocation());
 
@@ -70,7 +71,10 @@ public final class ClientSetup {
         }
 
         ForgeModelBakery.addSpecialModel(new ResourceLocation(RefinedPipes.ID + ":block/pipe/attachment/inventory_attachment"));
+    }
 
+    @SubscribeEvent
+    public static void onClientSetup(FMLClientSetupEvent e) {
         MenuScreens.register(RefinedPipesContainerMenus.EXTRACTOR_ATTACHMENT, ExtractorAttachmentScreen::new);
 
         ItemBlockRenderTypes.setRenderLayer(RefinedPipesBlocks.BASIC_ITEM_PIPE, RenderType.cutout());


### PR DESCRIPTION
The JavaDoc on `ForgeModelBakery.addSpecialModel` states that it should be called during `ModelRegistryEvent`, and the current location seems to be racing with that event. When special models are registered too late there isn't any immediate error, the models just aren't loaded and placing a pipe will throw an NPE since the `core` model is `null`.

For me this crash is pretty reliable, and on ForgeCraft it actually happens immediately before the main menu since CTM queries all models then.